### PR TITLE
Fix 7249

### DIFF
--- a/dataprep_ml/cleaners.py
+++ b/dataprep_ml/cleaners.py
@@ -172,6 +172,7 @@ def _standardize_datetime(element: pd.Series) -> pd.Series:
 # Tags/Sequences
 # ------------------------- #
 
+
 # TODO Make it split on something other than commas
 def _tags_to_tuples(tags_str: str) -> Tuple[str]:
     """

--- a/dataprep_ml/cleaners.py
+++ b/dataprep_ml/cleaners.py
@@ -163,11 +163,10 @@ def _standardize_datetime(element: pd.Series) -> pd.Series:
         result = pd.to_datetime(element,
                                 infer_datetime_format=True,
                                 format='mixed').apply(lambda x: x.timestamp())
-    except Exception as error:
+    except ValueError:
         pass
 
     return result
-
 
 # ------------------------- #
 # Tags/Sequences
@@ -211,7 +210,7 @@ def _standardize_num_array(element: object) -> Optional[Union[List[float], float
             element = _clean_float(element)
         else:
             element = [float(x) for x in element.split(" ")]
-    except ValueError:
+    except Exception:
         pass
 
     return element

--- a/dataprep_ml/cleaners.py
+++ b/dataprep_ml/cleaners.py
@@ -149,7 +149,24 @@ def get_cleaning_func(data_dtype: dtype, custom_cleaning_functions: Dict[str, st
 # ------------------------- #
 
 def _standardize_datetime(element: pd.Series) -> pd.Series:
-    return pd.to_datetime(element, infer_datetime_format=True).apply(lambda x: x.timestamp())
+    """ Converts pandas.Series into pandas.Timestamp Series.
+
+        :param element: pandas.Series
+        :returns pandas.Series, None
+
+        :note
+            Returns `None` if the routine fails to extract
+            a `pandas.Timestamp` from any entry of `element`.
+    """
+    result = None
+    try:
+        result = pd.to_datetime(element,
+                                infer_datetime_format=True,
+                                format='mixed').apply(lambda x: x.timestamp())
+    except Exception as error:
+        pass
+
+    return result
 
 
 # ------------------------- #

--- a/dataprep_ml/cleaners.py
+++ b/dataprep_ml/cleaners.py
@@ -211,7 +211,7 @@ def _standardize_num_array(element: object) -> Optional[Union[List[float], float
             element = _clean_float(element)
         else:
             element = [float(x) for x in element.split(" ")]
-    except Exception:
+    except ValueError:
         pass
 
     return element


### PR DESCRIPTION
This PR is to fixes bug https://github.com/mindsdb/mindsdb/issues/7249

A patch was applied to function `_standarize_datetime()` so that the function returns `None` if it fails to parse any element of the input series into a `pandas.Timestamp` object. I added documentation to the routine as well.