### PR TITLE
[Fix] Cast orderby to numerical, check TS length before finalizing split

### DIFF
--- a/dataprep_ml/cleaners.py
+++ b/dataprep_ml/cleaners.py
@@ -507,6 +507,10 @@ def clean_timeseries(df: pd.DataFrame, tss: dict) -> pd.DataFrame:
 
     # save original order of columns
     orig_cols = deepcopy(df.columns.to_list())
+
+    # cast order_by as numerical
+    df[tss['order_by']] = pd.to_numeric(df[tss['order_by']], errors='raise')
+
     # fix duplicates by group
     if tss.get('group_by', False):
         correct_dfs = []

--- a/dataprep_ml/splitters.py
+++ b/dataprep_ml/splitters.py
@@ -57,6 +57,13 @@ def splitter(
     else:
         train, dev, test = simple_split(data, pct_train, pct_dev, pct_test)
 
+    # Final assertions for time series
+    if min(len(train), len(dev)) < tss.get('window'):
+        raise Exception(f"Dataset size is too small for the specified window size ({tss.get('window')})")
+
+    if min(len(train), len(dev), len(test)) < tss.get('horizon'):
+        raise Exception(f"Dataset size is too small for the specified horizon size ({tss.get('horizon')})")
+
     return {"train": train, "test": test, "dev": dev, "stratified_on": stratify_on}
 
 

--- a/dataprep_ml/splitters.py
+++ b/dataprep_ml/splitters.py
@@ -59,10 +59,10 @@ def splitter(
 
     # Final assertions for time series
     if min(len(train), len(dev)) < tss.get('window', 1):
-        raise Exception(f"Dataset size is too small for the specified window size ({tss.get('window')})")
+        raise Exception(f"Dataset size is too small for the specified window size ({tss.get('window', 1)})")
 
     if min(len(train), len(dev), len(test)) < tss.get('horizon', 1):
-        raise Exception(f"Dataset size is too small for the specified horizon size ({tss.get('horizon')})")
+        raise Exception(f"Dataset size is too small for the specified horizon size ({tss.get('horizon', 1)})")
 
     return {"train": train, "test": test, "dev": dev, "stratified_on": stratify_on}
 

--- a/dataprep_ml/splitters.py
+++ b/dataprep_ml/splitters.py
@@ -58,10 +58,10 @@ def splitter(
         train, dev, test = simple_split(data, pct_train, pct_dev, pct_test)
 
     # Final assertions for time series
-    if min(len(train), len(dev)) < tss.get('window'):
+    if min(len(train), len(dev)) < tss.get('window', 1):
         raise Exception(f"Dataset size is too small for the specified window size ({tss.get('window')})")
 
-    if min(len(train), len(dev), len(test)) < tss.get('horizon'):
+    if min(len(train), len(dev), len(test)) < tss.get('horizon', 1):
         raise Exception(f"Dataset size is too small for the specified horizon size ({tss.get('horizon')})")
 
     return {"train": train, "test": test, "dev": dev, "stratified_on": stratify_on}


### PR DESCRIPTION
Minor fixes motivated by [mindsdb#8358](https://github.com/mindsdb/mindsdb/issues/8358):

- Check split lengths before admitting split as valid in forecast scenarios
- Cast order by column to numerical in forecast scenarios